### PR TITLE
build(docker): 修改 docker:up 命令以使用 .env.development 环境变量

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "docker:build:dev": "docker compose --env-file .env --env-file .env.development up --build",
     "docker:build": "docker compose --env-file .env --env-file .env.production up --build",
     "docker:prod:up": "docker compose -f docker-compose.prod.yml --env-file .env --env-file .env.production up -d --pull=always",
-    "docker:up": "docker compose --env-file .env --env-file .env.production up -d --no-build",
+    "docker:up": "docker compose --env-file .env --env-file .env.development up -d --no-build",
     "docker:down": "docker compose --env-file .env --env-file .env.production down",
     "docker:rmi": "docker compose --env-file .env --env-file .env.production stop nest-admin-server && docker container rm nest-admin-server && docker rmi nest-admin-server",
     "docker:logs": "docker compose --env-file .env --env-file .env.production logs -f"


### PR DESCRIPTION
- 将 "docker:up" 命令的环境变量从 .env.production 改为 .env.development
- 此修改使得开发时默认使用开发环境配置，提高调试效率